### PR TITLE
Add  optional Scrypt request penalty in order to demonstrate autoscaling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,12 +37,14 @@ targetCompatibility = 1.8
 
 dependencies {
     compile("org.springframework.boot:spring-boot-starter-web")
-    compile 'org.springframework.boot:spring-boot-starter-freemarker'
+    compile("org.springframework.boot:spring-boot-starter-freemarker")
     compile("org.springframework.boot:spring-boot-starter-actuator")
     compile("org.springframework.boot:spring-boot-starter-data-jpa")
+    compile("org.springframework.boot:spring-boot-starter-security")
+    compile("org.springframework.boot:spring-boot-devtools")
+    compile("org.bouncycastle:bcprov-jdk15on:1.60")
     compile("org.hsqldb:hsqldb")
     compile("mysql:mysql-connector-java")
-    compile("org.springframework.boot:spring-boot-devtools")
     compile("javax.xml.bind:jaxb-api")
     compile("io.micrometer:micrometer-registry-prometheus")
     testCompile("junit:junit")

--- a/app/src/main/java/uob_todo/SecurityConfig.java
+++ b/app/src/main/java/uob_todo/SecurityConfig.java
@@ -1,0 +1,15 @@
+package uob_todo;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.authorizeRequests().antMatchers("/**").permitAll();
+    }
+
+}

--- a/app/src/main/java/uob_todo/api/TodoController.java
+++ b/app/src/main/java/uob_todo/api/TodoController.java
@@ -1,6 +1,7 @@
 package uob_todo.api;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 import uob_todo.api.exceptions.BadRequestException;
 import uob_todo.api.exceptions.NotFoundException;
@@ -11,6 +12,21 @@ public class TodoController {
 
     private final TodoRepository todoSource;
 
+    /*
+    This function runs a cpu/memory penalty in order to generate some fake load. This is used to drive metrics
+    examples and demonstrate auto-scaling of pods/containers.
+     */
+    private void runPenaltyIfRequired() {
+        SCryptPasswordEncoder encoder = new SCryptPasswordEncoder(
+                1 << 14,
+                8,
+                1,
+                32,
+                64
+        );
+        encoder.encode("");
+    }
+
     @Autowired
     public TodoController(TodoRepository todoSource){
         this.todoSource = todoSource;
@@ -18,16 +34,19 @@ public class TodoController {
 
     @GetMapping("/{id}")
     public TodoItem getTodo(@PathVariable("id") Long id) throws Exception {
+        this.runPenaltyIfRequired();
         return todoSource.findById(id).orElseThrow(() -> new NotFoundException("item not found"));
     }
 
     @GetMapping()
     public Iterable<TodoItem> listTodos() {
+        this.runPenaltyIfRequired();
         return todoSource.findAll();
     }
 
     @PostMapping()
     public TodoItem createTodo(@RequestBody TodoItem item) throws Exception {
+        this.runPenaltyIfRequired();
         if (item.getTitle().equals("")) {
             throw new BadRequestException("empty 'title'");
         }
@@ -36,6 +55,7 @@ public class TodoController {
 
     @PutMapping("/{id}")
     public TodoItem updateTodo(@PathVariable("id") Long id, @RequestBody TodoItem item) throws Exception {
+        this.runPenaltyIfRequired();
         if (item.getTitle().equals("")) {
             throw new BadRequestException("empty 'title'");
         }

--- a/app/src/main/java/uob_todo/api/TodoController.java
+++ b/app/src/main/java/uob_todo/api/TodoController.java
@@ -1,6 +1,7 @@
 package uob_todo.api;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 import uob_todo.api.exceptions.BadRequestException;
@@ -12,19 +13,17 @@ public class TodoController {
 
     private final TodoRepository todoSource;
 
+    @Value("${todoapp.penalty.factor}")
+    private int penaltyFactor;
+
     /*
     This function runs a cpu/memory penalty in order to generate some fake load. This is used to drive metrics
     examples and demonstrate auto-scaling of pods/containers.
      */
     private void runPenaltyIfRequired() {
-        SCryptPasswordEncoder encoder = new SCryptPasswordEncoder(
-                1 << 14,
-                8,
-                1,
-                32,
-                64
-        );
-        encoder.encode("");
+        if (penaltyFactor > 0) {
+            new SCryptPasswordEncoder(1 << penaltyFactor, 8, 1, 32, 64).encode("");
+        }
     }
 
     @Autowired

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -6,3 +6,5 @@ management.endpoints.web.exposure.include=health,prometheus
 
 # database settings
 spring.jpa.hibernate.ddl-auto=update
+
+# custom settings

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -4,7 +4,10 @@ management.endpoint.health.enabled=true
 management.endpoint.prometheus.enabled=true
 management.endpoints.web.exposure.include=health,prometheus
 
-# database settings
+# === Database Settings ===
 spring.jpa.hibernate.ddl-auto=update
 
-# custom settings
+# === Custom Settings ===
+# penalty factor is used to add an scrypt CPU cost to any /api/todos requests
+# if required. 0 = no cost, a reasonable value is in the 12-15 range.
+todoapp.penalty.factor = 0


### PR DESCRIPTION
This adds an Scrypt cpu/memory penalty to TodoController api requests.

By default it is 0, but can be increased using a java property.

This adds a security config to not require auth (which is added by default when spring boot security is imported).